### PR TITLE
Use sub-class instead of monkey-patching

### DIFF
--- a/lib/jekyll-algolia.rb
+++ b/lib/jekyll-algolia.rb
@@ -25,8 +25,7 @@ module Jekyll
     # monkey-patching its `write` method and building it.
     def self.init(config = {})
       @config = config
-      @site = Jekyll::Site.new(@config)
-      monkey_patch_site(@site)
+      @site = Jekyll::Algolia::Site.new(@config)
 
       exit 1 unless Configurator.assert_valid_credentials
 
@@ -60,15 +59,13 @@ module Jekyll
       @site
     end
 
-    # Public: Replace the main `write` method of the site to push records to
-    # Algolia instead of writing files to disk.
     #
-    # site - The Jekyll site to monkey patch
-    #
-    # We will change the behavior of the `write` method that should write files
-    # to disk and have it create JSON records and push them to Algolia instead.
-    def self.monkey_patch_site(site)
-      def site.write
+
+    # A Jekyll::Site subclass that overrides #write from the parent class to
+    # create JSON records out of rendered documents and push those records
+    # to Algolia instead of writing files to disk.
+    class Site < Jekyll::Site
+      def write
         if Configurator.dry_run?
           Logger.log('W:==== THIS IS A DRY RUN ====')
           Logger.log('W:  - No records will be pushed to your index')

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -42,20 +42,17 @@ describe(Jekyll::Algolia) do
     end
   end
 
-  describe '.monkey_patch_site' do
+  describe 'overriding Jekyll::Site#write' do
     # Given
-    let(:site) { Jekyll::Site.new(Jekyll.configuration) }
-    let!(:initial_method) { site.method(:write).source_location }
-
-    # When
-    subject do
-      current.monkey_patch_site(site)
-      site.method(:write).source_location
-    end
+    let(:configuration) { Jekyll.configuration }
+    let(:jekyll_site) { Jekyll::Site.new(configuration) }
+    let(:algolia_site) { Jekyll::Algolia::Site.new(configuration) }
+    let!(:initial_method) { jekyll_site.method(:write).source_location }
+    let!(:overridden_method) { algolia_site.method(:write).source_location }
 
     # Then
     it 'should change the initial .write method' do
-      expect(subject).to_not eq initial_method
+      expect(overridden_method).to_not eq initial_method
     end
   end
 
@@ -68,17 +65,14 @@ describe(Jekyll::Algolia) do
     end
 
     let(:configuration) { Jekyll.configuration }
-    let(:jekyll_site) { double('Jekyll::Site', process: nil) }
+    let(:algolia_site) { double('Jekyll::Algolia::Site', process: nil) }
     before do
       # Making sure all methods are called on the relevant objects
-      expect(Jekyll::Site)
+      expect(Jekyll::Algolia::Site)
         .to receive(:new)
         .with(configuration)
-        .and_return(jekyll_site)
-      expect(current)
-        .to receive(:monkey_patch_site)
-        .with(jekyll_site)
-      expect(jekyll_site)
+        .and_return(algolia_site)
+      expect(algolia_site)
         .to receive(:process)
     end
 


### PR DESCRIPTION
You can override `Jekyll::Site#write` by redefining the method in a sub-class instead of monkey-patching a Jekyll Core class