### PR TITLE
Rubocop: Target Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ require:
 
 AllCops:
   DisplayCopNames: true
+  Exclude:
+    - vendor/**/*
+    - spec/site/**/*
+  TargetRubyVersion: 2.3
 
 Metrics/AbcSize:
   Max: 100
@@ -18,6 +22,8 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   Max: 50
+  Exclude:
+    - spec/jekyll/algolia/indexer_spec.rb
 
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Dependencies are defined in the .gemspec file

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Launch tests whenever a file in ./lib or ./spec changes
 guard :rspec, cmd: 'bundle exec rspec --color --format progress' do
   watch(%r{^spec/.+_spec\.rb$})

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 begin
@@ -14,9 +16,7 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:lint) do |task|
   task.patterns = [
     'lib/**/*.rb',
-    # Excluding ./spec/site
-    'spec/*.rb',
-    'spec/jekyll/**/*.rb'
+    'spec/**/*.rb'
   ]
   task.options = ['--display-cop-names']
 end

--- a/jekyll-algolia.gemspec
+++ b/jekyll-algolia.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.join(File.dirname(__FILE__), 'lib/jekyll/algolia/version.rb')
 
 Gem::Specification.new do |gem|
@@ -15,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.licenses = ['MIT']
 
   # Dependencies
-  gem.add_runtime_dependency 'algoliasearch', '~> 1.18'
   gem.add_runtime_dependency 'algolia_html_extractor', '~> 2.1'
+  gem.add_runtime_dependency 'algoliasearch', '~> 1.18'
   gem.add_runtime_dependency 'awesome_print', '~> 1.8'
   gem.add_runtime_dependency 'filesize', '~> 0.1'
   gem.add_runtime_dependency 'jekyll', '~> 3.6'
@@ -37,10 +39,10 @@ Gem::Specification.new do |gem|
 
   # Files
   gem.files = Dir[
-    'lib/**/*.rb',
-    'errors/*.txt',
-    'README.md',
     'CONTRIBUTING.md',
+    'errors/*.txt',
+    'lib/**/*.rb',
     'LICENSE.txt',
+    'README.md',
   ]
 end

--- a/lib/jekyll-algolia.rb
+++ b/lib/jekyll-algolia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jekyll/commands/algolia'
 
 module Jekyll

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Algolia
     # Single source of truth for access to configuration variables
@@ -83,7 +85,7 @@ module Jekyll
         source_dir = get('source')
         if source_dir
           api_key_file = File.join(source_dir, '_algolia_api_key')
-          if File.exist?(api_key_file) && File.size(api_key_file) > 0
+          if File.exist?(api_key_file) && File.size(api_key_file).positive?
             return File.open(api_key_file).read.strip
           end
         end

--- a/lib/jekyll/algolia/error_handler.rb
+++ b/lib/jekyll/algolia/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'verbal_expressions'
 require 'filesize'
 require 'cgi'

--- a/lib/jekyll/algolia/extractor.rb
+++ b/lib/jekyll/algolia/extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require 'algoliasearch'
 # require 'json'
 require 'algolia_html_extractor'

--- a/lib/jekyll/algolia/file_browser.rb
+++ b/lib/jekyll/algolia/file_browser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'algolia_html_extractor'
 
 module Jekyll

--- a/lib/jekyll/algolia/indexer.rb
+++ b/lib/jekyll/algolia/indexer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'algoliasearch'
 
 module Jekyll

--- a/lib/jekyll/algolia/logger.rb
+++ b/lib/jekyll/algolia/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Algolia
     # Display helpful error messages

--- a/lib/jekyll/algolia/user_hooks.rb
+++ b/lib/jekyll/algolia/user_hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   # Hooks that can be safely overwritten by the user
   module Algolia

--- a/lib/jekyll/algolia/utils.rb
+++ b/lib/jekyll/algolia/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 
 module Jekyll

--- a/lib/jekyll/algolia/version.rb
+++ b/lib/jekyll/algolia/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Algolia
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.0'
   end
 end

--- a/lib/jekyll/commands/algolia.rb
+++ b/lib/jekyll/commands/algolia.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'awesome_print'
 
 module Jekyll

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -1,17 +1,20 @@
 #!/usr/bin/env ruby
-require_relative '../lib/version.rb'
+# frozen_string_literal: true
 
+require_relative '../lib/jekyll/algolia/version.rb'
+
+# Bump Version
 class BumpVersion
   def initialize(*args)
     @type = args[0]
-    if !valid_type?(@type)
+    unless valid_type?(@type)
       puts "Invalid bump type: #{@type}"
       exit 1
     end
   end
 
   def valid_type?(type)
-    %w(major minor patch).include?(type)
+    %w[major minor patch].include?(type)
   end
 
   def bump(current_version, type)
@@ -33,8 +36,7 @@ class BumpVersion
     old_version = AlgoliaSearchJekyllVersion.to_s
     new_version = bump(old_version, @type)
 
-    script_dir = File.expand_path(File.dirname(__FILE__))
-    file = File.join(script_dir, '../lib/version.rb')
+    file = File.join(__dir__, '../lib/version.rb')
     old_content = File.read(file)
     new_content = old_content.gsub(old_version, new_version)
     File.write(file, new_content)
@@ -42,6 +44,5 @@ class BumpVersion
     `git add #{file}`
     `git commit -m "chore(bump): Version bump to #{new_version}"`
   end
-
 end
 BumpVersion.new(*ARGV).run

--- a/scripts/check_flay
+++ b/scripts/check_flay
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 MAX_SCORE = 45
 
@@ -21,7 +22,7 @@ flay_lines.each_with_index do |line, index|
   }
 end
 
-exit 0 if errors.size == 0
+exit 0 if errors.empty?
 
 puts 'Flay test failed:'
 errors.sort_by { |a| a[:score] }.each do |error|

--- a/scripts/check_flog
+++ b/scripts/check_flog
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 MAX_SCORE = 45
 
@@ -22,7 +23,7 @@ flog_lines.each_with_index do |line, index|
   }
 end
 
-exit 0 if errors.size == 0
+exit 0 if errors.empty?
 
 puts 'Flog test failed:'
 errors.sort_by { |a| a[:score] }.each do |error|

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/error_handler_spec.rb
+++ b/spec/jekyll/algolia/error_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/extractor_spec.rb
+++ b/spec/jekyll/algolia/extractor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/file_browser_spec.rb
+++ b/spec/jekyll/algolia/file_browser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe(Jekyll::Algolia::Indexer) do

--- a/spec/jekyll/algolia/logger_spec.rb
+++ b/spec/jekyll/algolia/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/jekyll/algolia/utils_spec.rb
+++ b/spec/jekyll/algolia/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 

--- a/spec/site/Gemfile
+++ b/spec/site/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -8,10 +8,11 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.6.2"
+gem 'jekyll', '~> 3.6.2'
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.0"
+# This is the default theme for new Jekyll sites.
+# You may change this to anything you like.
+gem 'minima', '~> 2.0'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -19,10 +20,9 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
-  gem "jekyll-algolia", :path => "../../"
+  gem 'jekyll-algolia', path: '../../'
+  gem 'jekyll-feed', '~> 0.6'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/spec/site/_plugins/algolia.rb
+++ b/spec/site/_plugins/algolia.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 module Jekyll
   # Custom hooks
   module Algolia
     def self.hook_should_be_excluded?(filepath)
       filepath == 'excluded-from-hook.html'
     end
+
     def self.hook_before_indexing_each(record, _node)
       record[:added_through_each] = true
       record
     end
+
     def self.hook_before_indexing_all(records)
       records << {
         name: 'Last one'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load coverage when run through Travis
 if ENV['TRAVIS']
   require 'coveralls'

--- a/spec/spec_helper_simplecov.rb
+++ b/spec/spec_helper_simplecov.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 
 SimpleCov.configure do


### PR DESCRIPTION
This PR is the result of defining Ruby 2.3 as a target and running the `rake lint:auto_correct` task.

```sh
$ rake lint:auto_correct
Running RuboCop...
Inspecting 22 files
......................

22 files inspected, no offenses detected
```

Note: The `frozen_string_literal: true` magic comment in Ruby can help dramatically decrease memory allocations for new strings and can thusly speed up your program.