### PR TITLE
Update file_browser.rb

### DIFF
--- a/lib/jekyll/algolia/file_browser.rb
+++ b/lib/jekyll/algolia/file_browser.rb
@@ -95,7 +95,7 @@ module Jekyll
           end
         end
 
-        excluded_files.include?(file.path)
+        excluded_files.include?(path_from_root(file))
       end
 
       # Public: Check if the file has been excluded by running a custom user


### PR DESCRIPTION
The current code will check if `/project/path/file/path.extension` is included on an array of paths in this form: `file/path.extension`. That'll always return false, so the files will never be excluded.

In my case, I have a project in `/Users/ale/Code/Website-frontend`, and in my `_config.yml` I have a `files_to_exclude: [_pages/**/*]` setting.

If I run `jekyll algolia` without this fix, one of my files is checked against the excluded files array using its full path (`/Users/ale/Code/Website-frontend/_pages/community/organizer-guide.md`), while the array contains its relative path (`_pages/community/organizer-guide.md`) so it doesn't match and it's included on the index.

I haven't had time to update the spec for this change, but since the tests still pass I assume there's something wrong with the existing tests.