### PR TITLE
Update blog.md to disable javascript minification

### DIFF
--- a/docs-src/src/blog.md
+++ b/docs-src/src/blog.md
@@ -111,7 +111,9 @@ search.start();
 
 The first lines will include the [InstantSearch.js][5] library as well as
 minimal styling, directly from the jsDeliver CDN. Those files are also available
-through [Yarn][6]/[NPM][7] if you need them locally.
+through [Yarn][6]/[NPM][7] if you need them locally. If you use the `jekyll-minifier`
+plugin, you'll need to set the option `compress_javascript: false` in Jekyll's `_config.yml`
+
 
 ### Instanciating the library
 


### PR DESCRIPTION
I needed to, at least. I was consistently getting the error `jekyll 3.7.3 | Error:  SyntaxError: Unexpected token: name (date)`, so adding a helping note (somewhere) would be nice, as it's pretty standard, and the default configuration of `jekyll-minifier` minifies javascript as well as SCSS.

Also, of note, is that I had to add a `<!--more-->` tag to my list of posts (before the `search-hits` id), lest it index a post's own snippet from the list of posts.