### PR TITLE
Collapse identical `Jekyll::Hooks.register` calls

### DIFF
--- a/lib/jekyll/algolia/overwrites/jekyll-algolia-site.rb
+++ b/lib/jekyll/algolia/overwrites/jekyll-algolia-site.rb
@@ -54,11 +54,7 @@ module Jekyll
           total: indexable_item_count,
           format: 'Rendering to HTML (%j%%) |%B|'
         )
-        Jekyll::Hooks.register :pages, :post_render do |_|
-          progress_bar.increment
-        end
-
-        Jekyll::Hooks.register :documents, :post_render do |_|
+        Jekyll::Hooks.register [:pages, :documents], :post_render do
           progress_bar.increment
         end
       end

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -322,10 +322,7 @@ describe(Jekyll::Algolia) do
           )
         expect(Jekyll::Hooks)
           .to have_received(:register)
-          .with(:pages, :post_render)
-        expect(Jekyll::Hooks)
-          .to have_received(:register)
-          .with(:documents, :post_render)
+          .with([:pages, :documents], :post_render)
       end
     end
 


### PR DESCRIPTION
`Jekyll::Hooks.register` can accept an array of *`owners`* to handle identical hook-events with a single block