### PR TITLE
Raise custom exception instead of SystemExit

### DIFF
--- a/lib/jekyll-algolia.rb
+++ b/lib/jekyll-algolia.rb
@@ -19,6 +19,8 @@ module Jekyll
     require 'jekyll/algolia/utils'
     require 'jekyll/algolia/version'
 
+    MissingCredentialsError = Class.new(StandardError)
+
     # Public: Init the Algolia module
     #
     # config - A hash of Jekyll config option (merge of _config.yml options and
@@ -33,7 +35,12 @@ module Jekyll
       config = Configurator.init(config).config
       @site = Jekyll::Algolia::Site.new(config)
 
-      exit 1 unless Configurator.assert_valid_credentials
+      unless Configurator.assert_valid_credentials
+        raise(
+          MissingCredentialsError,
+          "One or more credentials were not found for site at: #{@site.source}"
+        )
+      end
 
       Configurator.warn_of_deprecated_options
 

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -57,7 +57,7 @@ describe(Jekyll::Algolia) do
           .and_return(false)
       end
 
-      it { is_expected.to raise_error SystemExit }
+      it { is_expected.to raise_error Jekyll::Algolia::MissingCredentialsError }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'ostruct'
 
 RSpec.configure do |config|
   config.filter_run(focus: true)
-  config.fail_fast = true
+  config.fail_fast = false
   config.run_all_when_everything_filtered = true
   config.before do
     Jekyll::Algolia::Configurator.init


### PR DESCRIPTION
It is better to raise a custom Exception gracefully than to resign entirely with a `SystemExit`.

Moreover, Travis CI currently fails abruptly without any helpful messages because the Test Suite is additionally configured to "fail fast" on any errors.

This PR (in its current state) does not ensure that Travis will pass successfully. But will allow to gather insights on how best to proceed..