### PR TITLE
Avoiding autopages from jekyll paginate v2 to be indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Jekyll Algolia Plugin
 
 [![gem version][1]](https://rubygems.org/gems/jekyll-algolia)

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -260,6 +260,10 @@ module Jekyll
         config['pagination'] = {} unless config['pagination'].is_a?(Hash)
         config['pagination']['enabled'] = false
 
+        # Disable autopages for jekyll-paginate-v2
+        config['autopages'] = {} unless config['pagination'].is_a?(Hash)
+        config['autopages']['enabled'] = false
+
         # Disable tags from jekyll-tagging
         config['tag_page_dir'] = nil
         config['tag_page_layout'] = nil

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -261,7 +261,7 @@ module Jekyll
         config['pagination']['enabled'] = false
 
         # Disable autopages for jekyll-paginate-v2
-        config['autopages'] = {} unless config['pagination'].is_a?(Hash)
+        config['autopages'] = {} unless config['autopages'].is_a?(Hash)
         config['autopages']['enabled'] = false
 
         # Disable tags from jekyll-tagging

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -456,6 +456,20 @@ describe(Jekyll::Algolia::Configurator) do
       end
     end
 
+    context 'disable autopes for jekyll-paginate-v2' do
+      context 'with no pagination key' do
+        it { should include('autopages' => { 'enabled' => false }); }
+      end
+      context 'with a pagination key' do
+        let(:config) { { 'autopages' => { 'foo' => 'bar' } } }
+        it {
+          should include(
+            'autopages' => { 'foo' => 'bar', 'enabled' => false }
+          )
+        }
+      end
+    end
+
     context 'disable jekyll-tagging' do
       it { should include('tag_page_dir' => nil) }
       it { should include('tag_page_layout' => nil) }


### PR DESCRIPTION
While jekyll-algolia is disabling plugins, Jekyll pagination v2 is not completely stopped from producing pages with his [Autopages](https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-AUTOPAGES.md) functionality, and then are indexed.

Some additional disabling is necessary to avoid indexing autopages.