### PR TITLE
test(fix): Stop failing tests if credentials are wrong

### DIFF
--- a/lib/jekyll-algolia.rb
+++ b/lib/jekyll-algolia.rb
@@ -19,6 +19,8 @@ module Jekyll
     require 'jekyll/algolia/utils'
     require 'jekyll/algolia/version'
 
+    MissingCredentialsError = Class.new(StandardError)
+
     # Public: Init the Algolia module
     #
     # config - A hash of Jekyll config option (merge of _config.yml options and
@@ -33,7 +35,12 @@ module Jekyll
       config = Configurator.init(config).config
       @site = Jekyll::Algolia::Site.new(config)
 
-      exit 1 unless Configurator.assert_valid_credentials
+      unless Configurator.assert_valid_credentials
+        raise(
+          MissingCredentialsError,
+          "One or more credentials were not found for site at: #{@site.source}"
+        )
+      end
 
       Configurator.warn_of_deprecated_options
 

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -57,7 +57,7 @@ describe(Jekyll::Algolia) do
           .and_return(false)
       end
 
-      it { is_expected.to raise_error SystemExit }
+      it { is_expected.to raise_error Jekyll::Algolia::MissingCredentialsError }
     end
   end
 

--- a/spec/jekyll-algolia_spec.rb
+++ b/spec/jekyll-algolia_spec.rb
@@ -18,6 +18,9 @@ describe(Jekyll::Algolia) do
   before do
     allow(Jekyll.logger).to receive(:warn)
     allow(logger).to receive(:log)
+    allow(configurator)
+      .to receive(:assert_valid_credentials)
+      .and_return(true)
   end
 
   describe '.init' do
@@ -25,12 +28,6 @@ describe(Jekyll::Algolia) do
 
     context 'with valid Algolia credentials' do
       subject { current.init(config) }
-
-      before do
-        allow(configurator)
-          .to receive(:assert_valid_credentials)
-          .and_return(true)
-      end
 
       it 'should make the site accessible from the outside' do
         expect(subject.site.config).to include(config)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'ostruct'
 
 RSpec.configure do |config|
   config.filter_run(focus: true)
-  config.fail_fast = true
+  config.fail_fast = false
   config.run_all_when_everything_filtered = true
   config.before do
     Jekyll::Algolia::Configurator.init

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'ostruct'
 
 RSpec.configure do |config|
   config.filter_run(focus: true)
-  config.fail_fast = false
+  config.fail_fast = true
   config.run_all_when_everything_filtered = true
   config.before do
     Jekyll::Algolia::Configurator.init


### PR DESCRIPTION
Using a custom error instead of stopping the process, and making sure all tests calling `.init()` are stubbing the credentials as correct.