### PR TITLE
feat(settings): allow disabling overriding

### DIFF
--- a/docs-src/src/options.md
+++ b/docs-src/src/options.md
@@ -106,7 +106,14 @@ algolia:
 ```
 
 Settings defined here will take precedence over any setting you manually defined
-through the [Algolia dashboard][5] UI, though.
+through the [Algolia dashboard][5] UI, though. If you'd like this not to happen
+at all, and only take the dashboard settings in account, pass `false` to the
+settings configuration.
+
+```yml
+algolia:
+  settings: false
+```
 
 ## `indexing_batch_size`
 

--- a/docs-src/src/options.md
+++ b/docs-src/src/options.md
@@ -115,6 +115,9 @@ algolia:
   settings: false
 ```
 
+We suggest users to at least run with the default settings once, so that the default
+relevance settings are set, which you can override via the dashboard after.
+
 ## `indexing_batch_size`
 
 This option defines the number of operations that will be grouped as part of one

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -159,9 +159,8 @@ module Jekyll
       # This will be a merge of default settings and the one defined in the
       # _config.yml file
       def self.settings
-        if algolia('settings') == false
-          return false
-        end
+        return {} if algolia('settings') == false
+
         user_settings = algolia('settings') || {}
         ALGOLIA_DEFAULTS['settings'].merge(user_settings)
       end

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -159,6 +159,9 @@ module Jekyll
       # This will be a merge of default settings and the one defined in the
       # _config.yml file
       def self.settings
+        if algolia('settings') == false
+          return false
+        end
         user_settings = algolia('settings') || {}
         ALGOLIA_DEFAULTS['settings'].merge(user_settings)
       end

--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -103,7 +103,7 @@ module Jekyll
       # Returns the value of this option, or the default value
       def self.algolia(key)
         config = get('algolia') || {}
-        value = config[key] || ALGOLIA_DEFAULTS[key]
+        value = config[key].nil? ? ALGOLIA_DEFAULTS[key] : config[key]
 
         # No value found but we have a method to define the default value
         if value.nil? && respond_to?("default_#{key}")

--- a/lib/jekyll/algolia/indexer.rb
+++ b/lib/jekyll/algolia/indexer.rb
@@ -296,9 +296,8 @@ module Jekyll
       # If the settingID are not matching, it means our config is different, so
       # we push it, overriding the settingID for next push.
       def self.update_settings
-        if Configurator.settings == false
-          return
-        end
+        return {} if Configurator.settings.empty?
+
         current_remote_settings = remote_settings || {}
         remote_setting_id = current_remote_settings.dig('userData', 'settingID')
 

--- a/lib/jekyll/algolia/indexer.rb
+++ b/lib/jekyll/algolia/indexer.rb
@@ -296,6 +296,9 @@ module Jekyll
       # If the settingID are not matching, it means our config is different, so
       # we push it, overriding the settingID for next push.
       def self.update_settings
+        if Configurator.settings == false
+          return
+        end
         current_remote_settings = remote_settings || {}
         remote_setting_id = current_remote_settings.dig('userData', 'settingID')
 

--- a/lib/jekyll/algolia/indexer.rb
+++ b/lib/jekyll/algolia/indexer.rb
@@ -296,7 +296,7 @@ module Jekyll
       # If the settingID are not matching, it means our config is different, so
       # we push it, overriding the settingID for next push.
       def self.update_settings
-        return {} if Configurator.settings.empty?
+        return if Configurator.settings.empty?
 
         current_remote_settings = remote_settings || {}
         remote_setting_id = current_remote_settings.dig('userData', 'settingID')

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -306,6 +306,15 @@ describe(Jekyll::Algolia::Configurator) do
       it { should include('attributeForDistinct' => 'title') }
       it { should include('customRanking' => ['asc(foo)', 'desc(bar)']) }
     end
+    context 'with settings false' do
+      before do
+        allow(current)
+          .to receive(:algolia)
+          .with('settings')
+          .and_return(false)
+      end
+      it { should equal(false) }
+    end
   end
 
   describe 'dry_run?' do

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -313,7 +313,7 @@ describe(Jekyll::Algolia::Configurator) do
           .with('settings')
           .and_return(false)
       end
-      it { should equal(false) }
+      it { should eql {} }
     end
   end
 

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -313,7 +313,7 @@ describe(Jekyll::Algolia::Configurator) do
           .with('settings')
           .and_return(false)
       end
-      it { should eql {} }
+      it { should be_empty }
     end
   end
 

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -754,7 +754,7 @@ describe(Jekyll::Algolia::Indexer) do
 
     describe 'should not update settings if user configured false' do
       let(:local_setting_id) { 'foo' }
-      let(:settings) { false }
+      let(:settings) { {} }
       let(:remote_settings) { {} }
       it do
         expect(current).to_not have_received(:set_settings)

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -632,6 +632,7 @@ describe(Jekyll::Algolia::Indexer) do
     let(:pluginVersion) { nil }
     let(:diff_keys) { nil }
     let(:force_settings) { nil }
+    let(:settings) { nil }
 
     before do
       stub_const('Jekyll::Algolia::VERSION', pluginVersion)

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -639,6 +639,9 @@ describe(Jekyll::Algolia::Indexer) do
       allow(configurator)
         .to receive(:force_settings?)
         .and_return(force_settings)
+      allow(configurator)
+        .to receive(:settings)
+        .and_return(settings)
       allow(current).to receive(:set_settings)
       allow(current).to receive(:warn_of_manual_dashboard_editing)
       allow(current).to receive(:local_setting_id).and_return(local_setting_id)
@@ -743,6 +746,15 @@ describe(Jekyll::Algolia::Indexer) do
       let(:local_setting_id) { 'foo' }
       let(:remote_settings) { { 'userData' => { 'settingID' => 'bar' } } }
       let(:dry_run) { true }
+      it do
+        expect(current).to_not have_received(:set_settings)
+      end
+    end
+
+    describe 'should not update settings if user configured false' do
+      let(:local_setting_id) { 'foo' }
+      let(:settings) { false }
+      let(:remote_settings) { {} }
       it do
         expect(current).to_not have_received(:set_settings)
       end

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -632,7 +632,7 @@ describe(Jekyll::Algolia::Indexer) do
     let(:pluginVersion) { nil }
     let(:diff_keys) { nil }
     let(:force_settings) { nil }
-    let(:settings) { Jekyll::Algolia::Configurator::ALGOLIA_DEFAULTS }
+    let(:settings) { Jekyll::Algolia::Configurator::ALGOLIA_DEFAULTS['settings'].merge({}) }
 
     before do
       stub_const('Jekyll::Algolia::VERSION', pluginVersion)

--- a/spec/jekyll/algolia/indexer_spec.rb
+++ b/spec/jekyll/algolia/indexer_spec.rb
@@ -632,7 +632,7 @@ describe(Jekyll::Algolia::Indexer) do
     let(:pluginVersion) { nil }
     let(:diff_keys) { nil }
     let(:force_settings) { nil }
-    let(:settings) { nil }
+    let(:settings) { Jekyll::Algolia::Configurator::ALGOLIA_DEFAULTS }
 
     before do
       stub_const('Jekyll::Algolia::VERSION', pluginVersion)


### PR DESCRIPTION
fixes #34 

New config value for `settings`: `false`. In this case the settings from the dashboard won't be overridden.