### PR TITLE
Delete key from config instead of resetting value

### DIFF
--- a/lib/jekyll/algolia/configurator.rb
+++ b/lib/jekyll/algolia/configurator.rb
@@ -255,10 +255,10 @@ module Jekyll
       # their values to nil values from here
       def self.disable_other_plugins(config)
         # Disable archive pages from jekyll-archives
-        config['jekyll-archives'] = nil
+        config.delete('jekyll-archives')
 
         # Disable pagination from jekyll-paginate
-        config['paginate'] = nil
+        config.delete('paginate')
 
         # Disable pagination for jekyll-paginate-v2
         config['pagination'] = {} unless config['pagination'].is_a?(Hash)
@@ -269,8 +269,8 @@ module Jekyll
         config['autopages']['enabled'] = false
 
         # Disable tags from jekyll-tagging
-        config['tag_page_dir'] = nil
-        config['tag_page_layout'] = nil
+        config.delete('tag_page_dir')
+        config.delete('tag_page_layout')
 
         config
       end

--- a/spec/jekyll/algolia/configurator_spec.rb
+++ b/spec/jekyll/algolia/configurator_spec.rb
@@ -435,11 +435,11 @@ describe(Jekyll::Algolia::Configurator) do
     subject { current.disable_other_plugins(config) }
 
     context 'disable jekyll-archives' do
-      it { should include('jekyll-archives' => nil) }
+      it { should_not include('jekyll-archives') }
     end
 
     context 'disable jekyll-paginate' do
-      it { should include('paginate' => nil) }
+      it { should_not include('paginate') }
     end
 
     context 'disable jekyll-paginate-v2' do
@@ -472,8 +472,8 @@ describe(Jekyll::Algolia::Configurator) do
     end
 
     context 'disable jekyll-tagging' do
-      it { should include('tag_page_dir' => nil) }
-      it { should include('tag_page_layout' => nil) }
+      it { should_not include('tag_page_dir') }
+      it { should_not include('tag_page_layout') }
     end
   end
 end


### PR DESCRIPTION
Closes #121

Semantically, deleting a key from a hash is the same as resetting it to `nil` as `config[key]` returns the same value in both cases.
However, there's a chance that the config hash is traversed using `Hash#fetch` which returns a given default value or calls a given block only if the said `key` doesn't exist in the hash. This results in differing behavior.

Hence, *deleting a config key is better than resetting it to `nil`*.

*An added benefit is that deleting a key frees allocated memory*.