### PR TITLE
Fix link to more versions of the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ plugins.
 
 [12]: https://community.algolia.com/instantsearch.js/
 
-[13]: https://www.algolia.com/press#resources
+[13]: https://www.algolia.com/press/?section=brand-guidelines
 
 [14]: https://github.com/ayastreb/
 


### PR DESCRIPTION
The current link to more versions of the logo links to the generic press page. One more click is necessary to reach the logos under 'Brand Guidelines'.