### PR TITLE
docs: add note about maintenance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Add fast and relevant search to your Jekyll site.
 
-> While this plugin was created by an Algolia employee, it is not an "officially supported API client". It is possible that future majors versions of Jekyll break compatibility, or require changes.
+> While this plugin was created by Algolia, it is not an officially supported API client. It is possible that future major versions of Jekyll break compatibility, or require changes.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Add fast and relevant search to your Jekyll site.
 
+> While this plugin was created by an Algolia employee, it is not an "officially supported API client". It is possible that future majors versions of Jekyll break compatibility, or require changes.
+
 ## Usage
 
 ```shell

--- a/docs-src/src/getting-started.md
+++ b/docs-src/src/getting-started.md
@@ -10,6 +10,8 @@ layout: content-with-menu.pug
 `jekyll-algolia` is a Jekyll plugin that lets you push all your content in an
 Algolia index.
 
+> While this plugin was created by an Algolia employee, it is not an "officially supported API client". It is possible that future majors versions of Jekyll break compatibility, or require changes.
+
 ## Requirements
 
 You'll need:

--- a/docs-src/src/getting-started.md
+++ b/docs-src/src/getting-started.md
@@ -10,7 +10,7 @@ layout: content-with-menu.pug
 `jekyll-algolia` is a Jekyll plugin that lets you push all your content in an
 Algolia index.
 
-> While this plugin was created by an Algolia employee, it is not an "officially supported API client". It is possible that future majors versions of Jekyll break compatibility, or require changes.
+> While this plugin was created by Algolia, it is not an officially supported API client. It is possible that future major versions of Jekyll break compatibility, or require changes.
 
 ## Requirements
 


### PR DESCRIPTION
This does not mean the plugin is _unmaintained_, but it's rather clarifying our position to be similar to other "community" plugins, like Gatsby.

fixes #136, to clarify that it's not under _active_ development, and thus news might be missed, but if a clear and straightforward fix is needed, or a PR is made, we will review it.