### PR TITLE
Expose --future and --drafts options

### DIFF
--- a/lib/jekyll/commands/algolia.rb
+++ b/lib/jekyll/commands/algolia.rb
@@ -24,6 +24,13 @@ module Jekyll
             command.option 'force_settings',
                            '--force-settings',
                            'Force updating of the index settings'
+            command.option 'future',
+                           '--future',
+                           'Index posts with a future date'
+            command.option 'show_drafts',
+                           '--drafts',
+                           '-D',
+                           'Index posts in the _drafts folder'
 
             command.action do |_, options|
               configuration = configuration_from_options(options)


### PR DESCRIPTION
Exposes the --future and --drafts options to the jekyll algolia command.

This works out quite nicely since these values end up just getting passed to the underlying site as it normally would with something like a jekyll build.

Could use testing, but this is my first Ruby commit, so I barely know where to begin. I tested manually on my machine, but that's by no means in-depth. If you tell me how, I'll do my due diligence, unless you just want to test yourself (I can be slow to respond).