### PR TITLE
Fix for undated drafts causing NoMethodError due to nil

### DIFF
--- a/lib/jekyll/algolia/overwrites/jekyll-document.rb
+++ b/lib/jekyll/algolia/overwrites/jekyll-document.rb
@@ -5,9 +5,10 @@ module Jekyll
   class Document
     # By default, Jekyll will set the current date (time of build) to any
     # collection item. This will break our diff algorithm, so we monkey patch
-    # this call to return nil if no date is defined instead.
+    # this call to return nil if no date is defined and the file is not a
+    # draft instead.
     def date
-      data['date'] || nil
+      data["date"] ||= (draft? ? source_file_mtime : nil)
     end
   end
 end


### PR DESCRIPTION
Alright, I think this might fix it. This is a slight derivation of the original Jekyll code modified to still contain the nil monkey patch.

Again, I have no idea how to write Ruby, so please review that the code actually makes sense. I haven't tested this once again because I'm not sure how to build the gem and install it and such.

Resolves algolia/jekyll-algolia#177