### PR TITLE
Change `actions/setup-ruby` to `ruby/setup-ruby`

### DIFF
--- a/docs-src/src/github-pages.md
+++ b/docs-src/src/github-pages.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
       - uses: actions/cache@v2


### PR DESCRIPTION
`actions/setup-ruby` has been deprecated, as mentioned in the following URL: https://github.com/actions/setup-ruby

Currently, using `actions/setup-ruby` fails the GitHub Actions workflow.